### PR TITLE
Add basic markdown blog

### DIFF
--- a/app/lib/posts.ts
+++ b/app/lib/posts.ts
@@ -1,0 +1,63 @@
+import { parse } from 'path'
+
+interface Post {
+  slug: string
+  title: string
+  summary: string
+  date: string
+  html: string
+}
+
+// Load all markdown files under ../posts as raw strings
+const files = import.meta.glob('../posts/*.md', { as: 'raw', eager: true }) as Record<string, string>
+
+type FrontMatter = { [key: string]: string }
+
+function parseFrontMatter(raw: string): { attributes: FrontMatter; body: string } {
+  const fmMatch = /^---\n([\s\S]+?)\n---\n?/m.exec(raw)
+  if (!fmMatch) return { attributes: {}, body: raw }
+  const fmLines = fmMatch[1].split(/\n/)
+  const attrs: FrontMatter = {}
+  for (const line of fmLines) {
+    const [key, ...rest] = line.split(':')
+    attrs[key.trim()] = rest.join(':').trim()
+  }
+  const body = raw.slice(fmMatch[0].length)
+  return { attributes: attrs, body }
+}
+
+function markdownToHtml(md: string): string {
+  return md
+    .replace(/^### (.*)$/gm, '<h3>$1</h3>')
+    .replace(/^## (.*)$/gm, '<h2>$1</h2>')
+    .replace(/^# (.*)$/gm, '<h1>$1</h1>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\n{2,}/g, '</p><p>')
+    .replace(/\n/g, '<br/>')
+    .replace(/^/, '<p>')
+    .replace(/$/, '</p>')
+}
+
+function buildPost(path: string, raw: string): Post {
+  const slug = parse(path).name
+  const { attributes, body } = parseFrontMatter(raw)
+  return {
+    slug,
+    title: attributes.title || slug,
+    summary: attributes.summary || '',
+    date: attributes.date || '',
+    html: markdownToHtml(body.trim()),
+  }
+}
+
+const allPosts: Post[] = Object.entries(files).map(([path, raw]) => buildPost(path, raw))
+
+export function getPosts() {
+  return allPosts.map(({ slug, title, summary, date }) => ({ slug, title, summary, date }))
+}
+
+export function getPost(slug: string) {
+  return allPosts.find((p) => p.slug === slug) || null
+}

--- a/app/posts/hello-nodejs-1.md
+++ b/app/posts/hello-nodejs-1.md
@@ -1,0 +1,15 @@
+---
+title: Hello Node.js
+summary: Introduction to Node.js and environment setup.
+date: 2024-01-01
+---
+
+# Hello Node.js
+
+Welcome to my first post about Node.js. In this article, we will explore how to set up a simple Node.js project and run it on your machine.
+
+1. Install Node.js from the official website.
+2. Create a new directory and run `npm init -y`.
+3. Add a simple `index.js` file and run it with `node index.js`.
+
+That's it! You now have a basic Node.js project.

--- a/app/posts/welcome.md
+++ b/app/posts/welcome.md
@@ -1,0 +1,9 @@
+---
+title: Welcome to the Blog
+summary: A short introduction to my new blog powered by Remix.
+date: 2024-05-15
+---
+
+# Welcome
+
+This is a demo post used to showcase the blog feature. Future articles about coding, DevOps and cloud computing will appear here. Stay tuned!

--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -1,0 +1,36 @@
+import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/cloudflare";
+import { json } from "@remix-run/cloudflare";
+import { useLoaderData } from "@remix-run/react";
+import { SITE_DOMAIN, SITE_NAME } from "~/lib/constants";
+import { getPost } from "~/lib/posts";
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  const slug = params.slug || "";
+  const post = getPost(slug);
+  if (!post) {
+    throw new Response("Not Found", { status: 404 });
+  }
+  return json({ post });
+};
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  if (!data?.post) return [{ title: "Post not found" }];
+  const { post } = data;
+  return [
+    { title: `${post.title} | ${SITE_NAME}` },
+    { name: "description", content: post.summary },
+    { name: "og:title", content: `${post.title} | ${SITE_NAME}` },
+    { name: "og:description", content: post.summary },
+    { name: "og:url", content: `https://${SITE_DOMAIN}/blog/${post.slug}` },
+  ];
+};
+
+export default function BlogPost() {
+  const { post } = useLoaderData<typeof loader>();
+  return (
+    <div className="container mx-auto max-w-2xl py-10">
+      <h1 className="text-4xl font-bold mb-8">{post.title}</h1>
+      <article className="prose" dangerouslySetInnerHTML={{ __html: post.html }} />
+    </div>
+  );
+}

--- a/app/routes/blog._index.tsx
+++ b/app/routes/blog._index.tsx
@@ -1,51 +1,43 @@
-import type { MetaFunction } from "@remix-run/cloudflare";
-import { Link } from "@remix-run/react";
-import { ArrowLeft, Construction } from "lucide-react";
-import { Button } from "~/components/ui/button";
+import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/cloudflare";
+import { json } from "@remix-run/cloudflare";
+import { Link, useLoaderData } from "@remix-run/react";
 import { SITE_DOMAIN, SITE_KEYWORDS, SITE_NAME } from "~/lib/constants";
+import { getPosts } from "~/lib/posts";
 
 export const meta: MetaFunction = () => {
   return [
     { title: `Blog | ${SITE_NAME}` },
-    { name: "description", content: "Blog sayfası yakında sizlerle olacak." },
-    {
-      name: "keywords",
-      content: SITE_KEYWORDS,
-    },
+    { name: "description", content: "Latest articles and tutorials." },
+    { name: "keywords", content: SITE_KEYWORDS },
     { name: "og:title", content: `Blog | ${SITE_NAME}` },
-    {
-      name: "og:description",
-      content: "Blog sayfası yakında sizlerle olacak.",
-    },
+    { name: "og:description", content: "Latest articles and tutorials." },
     { name: "og:url", content: `https://${SITE_DOMAIN}/blog` },
     { name: "og:image", content: `https://${SITE_DOMAIN}/og-image.png` },
   ];
 };
 
+export const loader = async (_args: LoaderFunctionArgs) => {
+  return json({ posts: getPosts() });
+};
+
 export default function Blog() {
+  const { posts } = useLoaderData<typeof loader>();
   return (
-    <div className="flex flex-col items-center justify-center min-h-[calc(100vh-8rem)] px-4 text-center">
-      <div className="animate-in fade-in slide-in-from-top-2 duration-400 flex flex-col items-center max-w-md">
-        <Construction className="h-16 w-16 text-primary mb-4" />
-
-        <h1 className="text-4xl font-bold mb-2">Blog Page</h1>
-
-        <div className="h-1 w-20 bg-primary my-4 rounded-full"></div>
-
-        <p className="text-xl mb-2">Coming Soon</p>
-
-        <p className="text-muted-foreground mb-8">
-          My blog is currently under construction. I will soon share my articles
-          about Golang, Rust, Next.js and other technologies here.
-        </p>
-
-        <Button asChild className="group">
-          <Link to="/" className="flex items-center gap-2">
-            <ArrowLeft className="h-4 w-4 group-hover:translate-x-[-2px] transition-transform" />
-            Back to Home
-          </Link>
-        </Button>
-      </div>
+    <div className="container mx-auto max-w-2xl py-10">
+      <h1 className="text-4xl font-bold mb-8">Blog</h1>
+      <ul className="space-y-6">
+        {posts.map((post) => (
+          <li key={post.slug} className="border-b pb-4">
+            <Link
+              to={`/blog/${post.slug}`}
+              className="text-2xl text-primary hover:underline"
+            >
+              {post.title}
+            </Link>
+            <p className="text-sm text-muted-foreground">{post.summary}</p>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- load markdown posts via a new utility
- list posts on `/blog`
- render single posts on `/blog/:slug`
- add two example markdown files

## Testing
- `pnpm run lint` *(fails: node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68428930530c8321b4a1f263f9014616