### PR TITLE
Add basic markdown blog

### DIFF
--- a/app/lib/posts.ts
+++ b/app/lib/posts.ts
@@ -1,3 +1,20 @@
+import posts from '../../public/mds/posts.json'
+
+export interface PostMeta {
+  slug: string
+  title: string
+  summary: string
+  date: string
+}
+
+export function getPosts(): PostMeta[] {
+  return posts as PostMeta[]
+}
+
+export function getPost(slug: string): PostMeta | null {
+  return (posts as PostMeta[]).find((p) => p.slug === slug) || null
+}
+
 import { parse } from 'path'
 
 interface Post {

--- a/app/routes/blog.$slug.tsx
+++ b/app/routes/blog.$slug.tsx
@@ -1,6 +1,8 @@
 import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/cloudflare";
 import { json } from "@remix-run/cloudflare";
 import { useLoaderData } from "@remix-run/react";
+import { useEffect, useState } from "react";
+import MDX from "@mdx-js/runtime";
 import { SITE_DOMAIN, SITE_NAME } from "~/lib/constants";
 import { getPost } from "~/lib/posts";
 
@@ -27,10 +29,18 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 
 export default function BlogPost() {
   const { post } = useLoaderData<typeof loader>();
+  const [content, setContent] = useState("");
+
+  useEffect(() => {
+    fetch(`/mds/${post.slug}.md`)
+      .then((res) => res.text())
+      .then((text) => setContent(text));
+  }, [post.slug]);
+
   return (
     <div className="container mx-auto max-w-2xl py-10">
       <h1 className="text-4xl font-bold mb-8">{post.title}</h1>
-      <article className="prose" dangerouslySetInnerHTML={{ __html: post.html }} />
+      {content ? <MDX>{content}</MDX> : <p>Loading...</p>}
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "tailwind-merge": "^3.2.0",
     "tiny-invariant": "^1.3.3",
     "vaul": "^0.9.6",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "@mdx-js/react": "^3.0.0",
+    "@mdx-js/runtime": "^3.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250505.0",

--- a/public/mds/hello-nodejs-1.md
+++ b/public/mds/hello-nodejs-1.md
@@ -1,0 +1,15 @@
+---
+title: Hello Node.js
+summary: Introduction to Node.js and environment setup.
+date: 2024-01-01
+---
+
+# Hello Node.js
+
+Welcome to my first post about Node.js. In this article, we will explore how to set up a simple Node.js project and run it on your machine.
+
+1. Install Node.js from the official website.
+2. Create a new directory and run `npm init -y`.
+3. Add a simple `index.js` file and run it with `node index.js`.
+
+That's it! You now have a basic Node.js project.

--- a/public/mds/posts.json
+++ b/public/mds/posts.json
@@ -1,0 +1,14 @@
+[
+  {
+    "slug": "hello-nodejs-1",
+    "title": "Hello Node.js",
+    "summary": "Introduction to Node.js and environment setup.",
+    "date": "2024-01-01"
+  },
+  {
+    "slug": "welcome",
+    "title": "Welcome to the Blog",
+    "summary": "A short introduction to my new blog powered by Remix.",
+    "date": "2024-05-15"
+  }
+]

--- a/public/mds/welcome.md
+++ b/public/mds/welcome.md
@@ -1,0 +1,9 @@
+---
+title: Welcome to the Blog
+summary: A short introduction to my new blog powered by Remix.
+date: 2024-05-15
+---
+
+# Welcome
+
+This is a demo post used to showcase the blog feature. Future articles about coding, DevOps and cloud computing will appear here. Stay tuned!


### PR DESCRIPTION
## Summary
- load markdown posts via a new utility
- list posts on `/blog`
- render single posts on `/blog/:slug`
- add two example markdown files

## Testing
- `pnpm run lint` *(fails: node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68428930530c8321b4a1f263f9014616